### PR TITLE
Allows define default config for Steward

### DIFF
--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup chart testing
         uses: helm/chart-testing-action@v2.0.1
       - name: Run chart-testing (lint)
-        run: ct lint
+        run: ct lint --chart-dirs helm --all
 
   publish:
     runs-on: ubuntu-18.04

--- a/.github/workflows/helm-ci.yaml
+++ b/.github/workflows/helm-ci.yaml
@@ -25,6 +25,7 @@ jobs:
         run: ct lint --chart-dirs helm --all
 
   publish:
+    needs: lint
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout the code

--- a/helm/steward/Chart.yaml
+++ b/helm/steward/Chart.yaml
@@ -3,5 +3,9 @@ type: application
 appVersion: "1.0"
 description: The helm chart for scala steward - the bot that helps you keep library dependencies and sbt plugins up-to-date.
 name: steward
-version: 0.1.11
+version: 0.1.12
 home: https://github.com/fthomas/scala-steward
+maintainers: 
+  - name: SoftwareMill
+    email: devops@softwaremill.com
+    url: https://github.com/softwaremill/steward-helm

--- a/helm/steward/Chart.yaml
+++ b/helm/steward/Chart.yaml
@@ -3,5 +3,5 @@ type: application
 appVersion: "1.0"
 description: The helm chart for scala steward - the bot that helps you keep library dependencies and sbt plugins up-to-date.
 name: steward
-version: 0.1.10
+version: 0.1.11
 home: https://github.com/fthomas/scala-steward

--- a/helm/steward/Chart.yaml
+++ b/helm/steward/Chart.yaml
@@ -5,7 +5,7 @@ description: The helm chart for scala steward - the bot that helps you keep libr
 name: steward
 version: 0.1.12
 home: https://github.com/fthomas/scala-steward
-maintainers: 
+maintainers:
   - name: SoftwareMill
     email: devops@softwaremill.com
     url: https://github.com/softwaremill/steward-helm

--- a/helm/steward/README.md
+++ b/helm/steward/README.md
@@ -34,6 +34,7 @@ The following table lists the configurable parameters of the chart and the defau
 | args | list | `["--workspace","/opt/scala-steward/workspace","--repos-file","/opt/config_values/repos.md","--git-author-name","$(GIT_AUTHOR_NAME)","--git-author-email","$(GIT_AUTHOR_EMAIL)","--vcs-api-host","https://api.github.com","--vcs-login","$(VCS_LOGIN)","--git-ask-pass","/opt/config_values/git_ask_pass_script.sh","--do-not-fork"]` | Arguments passed to steward binary |
 | askPassScript | string | `"#!/bin/bash\nset -u\necho ${VCS_TOKEN}"` | Script which echoes VCS token |
 | credentialsSbt | string | `""` | Sbt credentials |
+| defaultConf | string | `""` | Default Scala Steward config |
 | cron.interval | string | `"@daily"` | cron expression - when to run kubernetes CronJob |
 | cron.restartPolicy | string | `"OnFailure"` | Whether to restart cronjob on failure |
 | existingSecretName | string | `nil` | If empty, the chart will create the secret containing the vcs token.    If not empty - the already existing secret is used.    The secret should have a field names VCS_TOKEN |

--- a/helm/steward/templates/configmap.yaml
+++ b/helm/steward/templates/configmap.yaml
@@ -7,3 +7,5 @@ data:
 {{- .Values.askPassScript | nindent 4 }}
   repos.md: |-
 {{- .Values.repos | nindent 4 }}
+  default.scala-steward.conf: |-
+{{- .Values.defaultConf | nindent 4 }}

--- a/helm/steward/values.yaml
+++ b/helm/steward/values.yaml
@@ -26,6 +26,12 @@ credentialsSbt: |
 # If you need to provide Nexus credentials, uncomment the below lines and provide proper credentials
 #  credentials += Credentials("Some Nexus Repository Manager", "my.artifact.repo.net", "admin", "admin123")
 
+# -- default.scala-steward.conf
+defaultConf: |
+# This section allows to define a default config used be Scala Steward
+# Once the config was defined here you must modify `args` below and add:
+#   --default-repo-conf /opt/config_values/default.scala-steward.conf
+
 # -- If empty, the chart will create the secret containing the vcs token.
 #    If not empty - the already existing secret is used.
 #    The secret should have a field names VCS_TOKEN
@@ -59,6 +65,8 @@ args:
   - --git-ask-pass
   - "/opt/config_values/git_ask_pass_script.sh"
   - --do-not-fork
+# - --default-repo-conf
+# - "/opt/config_values/default.scala-steward.conf"
 
 persistence:
   # -- Whether enable persistent volume to store cache


### PR DESCRIPTION
This PR adds ability to define a default config used by Scala Steward, see [Running Steward](https://github.com/scala-steward-org/scala-steward/blob/master/docs/running.md#running-scala-steward) section and the `--default-repo-conf` option.